### PR TITLE
Can't drop database with dash in its name

### DIFF
--- a/src/model/database/databaseNode.ts
+++ b/src/model/database/databaseNode.ts
@@ -53,7 +53,7 @@ export class DatabaseNode extends Node implements CopyAble {
 
         vscode.window.showInputBox({ prompt: `Are you want to Delete Database ${this.database} ?     `, placeHolder: 'Input database name to confirm.' }).then(async (inputContent) => {
             if (inputContent && inputContent.toLowerCase() == this.database.toLowerCase()) {
-                QueryUnit.queryPromise(await ConnectionManager.getConnection(this), `DROP DATABASE ${this.database}`).then(() => {
+                QueryUnit.queryPromise(await ConnectionManager.getConnection(this), `DROP DATABASE \`${this.database}\``).then(() => {
                     DatabaseCache.clearDatabaseCache(`${this.getConnectId()}`)
                     DbTreeDataProvider.refresh();
                     vscode.window.showInformationMessage(`Delete database ${this.database} success!`)


### PR DESCRIPTION
This patch fixes this error message when clicking `Drop Database` in the context menu:

> Execute sql fail : DROP DATABASE test_345c3341-4556-41bd-baa9-bf651cdbf904
-----------------------------------------------------------------------------------------
>Error: ER_PARSE_ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-4556-41bd-baa9-bf651cdbf904' at line 1