### PR TITLE
Fix wrong dump file path on Ubuntu

### DIFF
--- a/src/service/dump/mysqlDumpService.ts
+++ b/src/service/dump/mysqlDumpService.ts
@@ -6,6 +6,7 @@ import { TableNode } from "../../model/main/tableNode";
 import { NodeUtil } from "../../model/nodeUtil";
 import { AbstractDumpService } from "./abstractDumpService";
 import format = require('date-format');
+import path = require('path');
 
 export class MysqlDumpService extends AbstractDumpService {
     protected dumpData(node: Node, exportPath: string, withData: boolean): void {
@@ -30,7 +31,7 @@ export class MysqlDumpService extends AbstractDumpService {
                     }
                 },
             },
-            dumpToFile: `${exportPath}\\${node.database}${tableName ? "_" + tableName : ''}_${format('yyyy-MM-dd_hhmmss', new Date())}.sql`,
+            dumpToFile: path.join(exportPath, `${node.database}${tableName ? "_" + tableName : ''}_${format('yyyy-MM-dd_hhmmss', new Date())}.sql`),
         };
         if (!withData) {
             option.dump.data = false;


### PR DESCRIPTION
# OS

Ubuntu 19.10

# Steps to reproduce

- Right click on the database name
- Click `Export Data`
- Navigate to `/home/me/Desktop`
- Click `Select export file path`
- Dump file full path `/home/me/Desktop\db_2020-05-22_185012.sql` (the file name is `Desktop\db_2020-05-22_185012.sql`)

# Expected result

Dump file path should be `/home/me/Desktop/db_2020-05-22_185012.sql`

# Notes

- [x] Patch tested on Ubuntu
- [ ] Patch tested on Windows