### PR TITLE
fix:spelling mistake

### DIFF
--- a/src/service/dialect/mysqlDialect.ts
+++ b/src/service/dialect/mysqlDialect.ts
@@ -91,8 +91,8 @@ export class MysqlDialect extends SqlDialect{
     tableTemplate(): string {
         return `CREATE TABLE [name](  
     id int NOT NULL primary key AUTO_INCREMENT comment 'primary key',
-    created_time DATETIME COMMENT 'created tiem',
-    updated_time DATETIME COMMENT 'updated tiem',
+    created_time DATETIME COMMENT 'created time',
+    updated_time DATETIME COMMENT 'updated time',
     [column] varchar(255) comment ''
 ) default charset utf8 comment '';`
     }


### PR DESCRIPTION
file:src/service/dialect/mysqlDialect.ts
function tableTemplate had a spelling mistake
"tiem" change to "time"