### PR TITLE
Click "Show Table Sources" and the table name is missing.

### DIFF
--- a/src/model/main/tableNode.ts
+++ b/src/model/main/tableNode.ts
@@ -65,14 +65,8 @@ export class TableNode extends Node implements CopyAble {
                 sql = sql.replace(/\\n/g, '\n');
             }
         } else {
-            const childs = await this.getChildren()
-            let table = this.table;
-            if (this.dbType == DatabaseType.MSSQL) {
-                const tables = this.table.split(".")
-                tables.shift()
-                table = tables.join(".")
-            }
-            sql = `CREATE TABLE ${table}(\n`
+            const childs = await this.getChildren();
+            sql = `CREATE TABLE ${this.table}(\n`
             for (let i = 0; i < childs.length; i++) {
                 const child: ColumnNode = childs[i] as ColumnNode;
                 if (i == childs.length - 1) {


### PR DESCRIPTION
There is no need to execute the "tables.shift()" function, just use the table name!
![image](https://user-images.githubusercontent.com/13539500/125574567-da9a815c-04a2-464e-a87d-fa33e44c4d44.png)
