### PR TITLE
Enable multi-select for redis keys to perform batch deletion

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -228,7 +228,7 @@ export function activate(context: vscode.ExtensionContext) {
                 "mysql.redis.connection.status": (connectionNode: RedisConnectionNode) => connectionNode.showStatus(),
                 "mysql.connection.terminal": (node: Node) => node.openTerminal(),
                 "mysql.redis.key.detail": (keyNode: KeyNode) => keyNode.detail(),
-                "mysql.redis.key.del": (keyNode: KeyNode) => keyNode.delete(),
+                "mysql.redis.key.del": (keyNode: KeyNode, keyNodeList: KeyNode[]) => keyNode.delete(keyNodeList),
                 "mysql.redis.loadMore": (renmainNode: RemainNode) => renmainNode.click(),
             },
             // table node

--- a/src/model/redis/keyNode.ts
+++ b/src/model/redis/keyNode.ts
@@ -30,12 +30,20 @@ export default class KeyNode extends RedisBaseNode {
         return [];
     }
 
-    public async delete() {
-        Util.confirm(`Are you want delete key ${this.label} ? `, async () => {
-            const client = await this.getClient();
-            await client.del(this.label)
-            this.provider.reload()
-        })
+    public async delete(keyNodeList: KeyNode[]) {
+        if (keyNodeList) {
+            Util.confirm('Do you want to delete all the selected keys' , async () => {
+                const client = await this.getClient();
+                await Promise.all(keyNodeList.map(n => client.del(n.label)))
+                this.provider.reload()
+            })
+        } else {
+            Util.confirm( `Do you want to delete the key ${this.label} ?`, async () => {
+                const client = await this.getClient();
+                await client.del(this.label)
+                this.provider.reload()
+            })
+        }
     }
 
 

--- a/src/service/serviceManager.ts
+++ b/src/service/serviceManager.ts
@@ -105,6 +105,7 @@ export class ServiceManager {
         this.nosqlProvider = new DbTreeDataProvider(this.context, CacheKey.NOSQL_CONNECTION);
         const treeview = vscode.window.createTreeView("github.cweijan.nosql", {
             treeDataProvider: this.nosqlProvider,
+            canSelectMany: true,
         });
         treeview.onDidCollapseElement((event) => {
             DatabaseCache.storeElementState(event.element, vscode.TreeItemCollapsibleState.Collapsed);


### PR DESCRIPTION
The canSelectMany option is only enabled for redis. And the folderNode is not considered.