### PR TITLE
Fix incorrect input type

### DIFF
--- a/src/vue/connect/component/SSH.vue
+++ b/src/vue/connect/component/SSH.vue
@@ -91,7 +91,7 @@
           <input
             class="w-64 field__input"
             placeholder="Passphrase"
-            type="passphrase"
+            type="password"
             v-model="connectionOption.ssh.passphrase"
           />
         </div>


### PR DESCRIPTION
The _Passphrase_ field when setting up SSH Tunnel is pure plaintext (already mentioned in #436) which is not ideal should someone be looking over your shoulder.

When observing the source code, it appears to be result of replacing `password` → `passphrase` which inadvertently created `<input type="passphrase">`.